### PR TITLE
Merge LGM and update to Kotlin 1.3.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,12 +2,12 @@ plugins {
     `maven-publish`
     `java-library`
     `kotlin-dsl`
-    kotlin("jvm") version "1.2.31"
+    kotlin("jvm") version "1.2.61"
     id("com.jfrog.bintray") version "1.8.4"
 }
 
 object KodeinVersions {
-    const val kotlinGradle = "1.2.31"
+    const val kotlinGradle = "1.2.61"
     const val kotlin = "1.3.0"
 }
 
@@ -34,25 +34,25 @@ dependencies {
     api("org.jetbrains.dokka:dokka-gradle-plugin:0.9.17")
 
     api("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
-    api("digital.wup:android-maven-publish:3.5.1")
+    api("digital.wup:android-maven-publish:3.6.2")
 
     api("com.github.salomonbrys.gradle.kotlin.js:kotlin-js-gradle-utils:1.0.0")
 }
 
 allprojects {
     group = "org.kodein.internal.gradle"
-    version = "2.0.2"
+    version = "2.0.2-LGM"
 
     afterEvaluate {
         val sourcesJar = task<Jar>("sourcesJar") {
             classifier = "sources"
             setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)
-            from(java.sourceSets["main"].allSource)
+            from(sourceSets["main"].allSource)
         }
 
         publishing {
-            (publications) {
-                "Kodein"(MavenPublication::class) {
+            publications {
+                create<MavenPublication>("Kodein") {
                     from(components["java"])
                     artifact(sourcesJar) {
                         classifier = "sources"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 object KodeinVersions {
     const val kotlinGradle = "1.2.61"
-    const val kotlin = "1.3.10"
+    const val kotlin = "1.3.20"
 }
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/src/main/kotlin/org/kodein/internal/gradle/KodeinLibraryAndroidPlugin.kt
+++ b/src/main/kotlin/org/kodein/internal/gradle/KodeinLibraryAndroidPlugin.kt
@@ -4,8 +4,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.plugin
 
 class KodeinLibraryAndroidPlugin : Plugin<Project> {
@@ -20,8 +20,8 @@ class KodeinLibraryAndroidPlugin : Plugin<Project> {
 
         @Suppress("UnstableApiUsage")
         extensions.configure<PublishingExtension>("publishing") {
-            (publications) {
-                "Kodein"(MavenPublication::class) {
+            publications {
+                create<MavenPublication>("Kodein") {
                     from(components["android"])
                 }
             }

--- a/src/main/kotlin/org/kodein/internal/gradle/KodeinLibraryJvmPlugin.kt
+++ b/src/main/kotlin/org/kodein/internal/gradle/KodeinLibraryJvmPlugin.kt
@@ -36,8 +36,8 @@ class KodeinLibraryJvmPlugin : Plugin<Project> {
             sourcesJar.from(sourceSets["main"].allSource)
 
             extensions.configure<PublishingExtension>("publishing") {
-                (publications) {
-                    "Kodein"(MavenPublication::class) {
+                publications {
+                    create<MavenPublication>("Kodein") {
                         from(components["java"])
                         artifact(sourcesJar)
                     }

--- a/src/main/kotlin/org/kodein/internal/gradle/KodeinUploadPlugin.kt
+++ b/src/main/kotlin/org/kodein/internal/gradle/KodeinUploadPlugin.kt
@@ -75,9 +75,9 @@ class KodeinUploadPlugin : Plugin<Project> {
                         val moduleFile = it.publishableFiles.firstOrNull { it.name == "module.json" }
                         if (moduleFile != null) {
                             uploadArtifact(Artifact().apply {
-                                name = it.mavenProjectIdentity.artifactId
-                                groupId = it.mavenProjectIdentity.groupId
-                                version = it.mavenProjectIdentity.version
+                                name = it.mavenProjectIdentity.artifactId.get()
+                                groupId = it.mavenProjectIdentity.groupId.get()
+                                version = it.mavenProjectIdentity.version.get()
                                 extension = "module"
                                 type = "module"
                                 file = moduleFile


### PR DESCRIPTION
This allows native projects to use the latest Kotlinx library releases with Kodein.