### PR TITLE
adding the ability to upload snapshot versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+stages:
+  - name: test
+    if: (tag IS NOT present) && (branch != master) && (branch != dev)
+  - name: snapshot
+    if: branch = dev
+  - name: release
+    if: branch = master
+
+os: linux
+language: java
+jdk: openjdk12
+
+jobs:
+  include:
+    - stage: test
+      script:
+#      - ./gradlew check
+      - echo $TRAVIS_BUILD_ID
+      - echo TRAVIS_BUILD_NUMBER
+    - stage: snapshot
+      script:
+#      - ./gradlew check bintrayUpload -PsnapshotNumber=2
+      - echo $TRAVIS_BUILD_ID
+      - echo TRAVIS_BUILD_NUMBER
+    - stage: release
+      script:
+#        - ./gradlew check bintrayUpload
+        - echo $TRAVIS_BUILD_ID
+        - echo TRAVIS_BUILD_NUMBER

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,24 @@
 stages:
   - name: test
-    if: (tag IS NOT present) && (branch != master) && (branch != dev)
   - name: snapshot
     if: branch = dev
   - name: release
     if: branch = master
 
-os: linux
-language: java
-jdk: openjdk12
-
 jobs:
   include:
     - stage: test
-      script:
-#      - ./gradlew check
-      - echo $TRAVIS_BUILD_ID
-      - echo TRAVIS_BUILD_NUMBER
+      script: ./gradlew check
+      os: linux
+      language: java
+      jdk: openjdk12
     - stage: snapshot
-      script:
-#      - ./gradlew check bintrayUpload -PsnapshotNumber=2
-      - echo $TRAVIS_BUILD_ID
-      - echo TRAVIS_BUILD_NUMBER
+      script: ./gradlew bintrayUpload -PsnapshotNumber=$TRAVIS_BUILD_NUMBER
+      os: linux
+      language: java
+      jdk: openjdk12
     - stage: release
-      script:
-#        - ./gradlew check bintrayUpload
-        - echo $TRAVIS_BUILD_ID
-        - echo TRAVIS_BUILD_NUMBER
+      script: ./gradlew bintrayUpload
+      os: linux
+      language: java
+      jdk: openjdk12

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 stages:
-  - name: test
   - name: snapshot
     if: branch = dev
   - name: release
@@ -7,11 +6,6 @@ stages:
 
 jobs:
   include:
-    - stage: test
-      script: ./gradlew check
-      os: linux
-      language: java
-      jdk: openjdk12
     - stage: snapshot
       script: ./gradlew bintrayUpload -PsnapshotNumber=$TRAVIS_BUILD_NUMBER
       os: linux

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 
 allprojects {
     group = "org.kodein.internal.gradle"
-    version = "2.6.0"
+    version = "2.6.1"
 
     afterEvaluate {
         val sourcesJar = task<Jar>("sourcesJar") {
@@ -71,7 +71,7 @@ allprojects {
                 user = bintrayUsername
                 key = bintrayApiKey
                 dryRun = bintrayDryRun == "true"
-                
+
                 pkg.apply {
                     if (bintrayUserOrg.isNotEmpty())
                         userOrg = bintrayUserOrg

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 
 allprojects {
     group = "org.kodein.internal.gradle"
-    version = "2.6.1"
+    version = "2.7.0"
 
     afterEvaluate {
         val sourcesJar = task<Jar>("sourcesJar") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,13 +60,13 @@ allprojects {
             }
         }
 
-        val bintrayUsername = "${properties["bintrayUsername"] ?: System.getenv("BINTRAY_USER")}"
-        val bintrayApiKey = "${properties["bintrayApiKey"] ?: System.getenv("BINTRAY_APIKEY")}"
-        val bintrayUserOrg = "${properties["bintrayUserOrg"] ?: System.getenv("BINTRAY_USER_ORG")}"
+        val bintrayUsername = (properties["bintrayUsername"] as String?) ?: System.getenv("BINTRAY_USER")
+        val bintrayApiKey = (properties["bintrayApiKey"] as String?) ?: System.getenv("BINTRAY_APIKEY")
+        val bintrayUserOrg = (properties["bintrayUserOrg"] as String?) ?: System.getenv("BINTRAY_USER_ORG")
         val bintrayDryRun: String? by project
         val snapshotNumber: String? by project
 
-        if (bintrayUsername.isNotEmpty() && bintrayApiKey.isNotEmpty()) {
+        if (bintrayUsername != null && bintrayApiKey != null) {
             bintray {
                 user = bintrayUsername
                 key = bintrayApiKey

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,18 +60,20 @@ allprojects {
             }
         }
 
-        if (hasProperty("bintrayUsername") && hasProperty("bintrayApiKey")) {
-            val bintrayUsername: String by project
-            val bintrayApiKey: String by project
-            val bintrayUserOrg: String? by project
-            val snapshotNumber: String? by project
+        val bintrayUsername = "${properties["bintrayUsername"] ?: System.getenv("BINTRAY_USER")}"
+        val bintrayApiKey = "${properties["bintrayApiKey"] ?: System.getenv("BINTRAY_APIKEY")}"
+        val bintrayUserOrg = "${properties["bintrayUserOrg"] ?: System.getenv("BINTRAY_USER_ORG")}"
+        val bintrayDryRun: String? by project
+        val snapshotNumber: String? by project
 
+        if (bintrayUsername.isNotEmpty() && bintrayApiKey.isNotEmpty()) {
             bintray {
                 user = bintrayUsername
                 key = bintrayApiKey
-
+                dryRun = bintrayDryRun == "true"
+                
                 pkg.apply {
-                    if (bintrayUserOrg != null)
+                    if (bintrayUserOrg.isNotEmpty())
                         userOrg = bintrayUserOrg
                     repo = "Kodein-Internal-Gradle"
                     name = project.name

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ allprojects {
 
                     if (snapshotNumber != null){
                         repo = "kodein-dev"
-                        project.version = "${project.version}-$snapshotNumber"
+                        project.version = "${project.version}-dev-$snapshotNumber"
                     }
 
                     setPublications("Kodein")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,7 @@ allprojects {
             val bintrayUsername: String by project
             val bintrayApiKey: String by project
             val bintrayUserOrg: String? by project
+            val snapshotNumber: String? by project
 
             bintray {
                 user = bintrayUsername
@@ -78,6 +79,11 @@ allprojects {
                     websiteUrl = "https://github.com/Kodein-Framework/kodein-internal-gradle-plugin"
                     issueTrackerUrl = "https://github.com/Kodein-Framework/kodein-internal-gradle-plugin/issues"
                     vcsUrl = "https://github.com/Kodein-Framework/kodein-internal-gradle-plugin.git"
+
+                    if (snapshotNumber != null){
+                        repo = "kodein-dev"
+                        project.version = "${project.version}-$snapshotNumber"
+                    }
 
                     setPublications("Kodein")
                 }

--- a/src/main/kotlin/org/kodein/internal/gradle/KodeinUploadPlugin.kt
+++ b/src/main/kotlin/org/kodein/internal/gradle/KodeinUploadPlugin.kt
@@ -27,16 +27,16 @@ class KodeinUploadPlugin : KtPlugin<Project> {
             return
         }
 
-        if (!hasProperty("bintrayUsername") || !hasProperty("bintrayApiKey")) {
+        val bintrayUsername = "${properties["bintrayUsername"] ?: System.getenv("BINTRAY_USER")}"
+        val bintrayApiKey = "${properties["bintrayApiKey"] ?: System.getenv("BINTRAY_APIKEY")}"
+        val bintrayUserOrg = "${properties["bintrayUserOrg"] ?: System.getenv("BINTRAY_USER_ORG")}"
+        val bintrayDryRun: String? by project
+        val snapshotNumber: String? by project
+
+        if (bintrayUsername.isEmpty() || bintrayApiKey.isEmpty()) {
             logger.warn("$project: Ignoring bintrayUpload in because bintrayUsername and/or bintrayApiKey is not set in gradle.properties.")
             return
         }
-
-        val bintrayUsername: String by project
-        val bintrayApiKey: String by project
-        val bintrayUserOrg: String? by project
-        val bintrayDryRun: String? by project
-        val snapshotNumber: String? by project
 
         bintray.apply {
             user = bintrayUsername
@@ -44,7 +44,7 @@ class KodeinUploadPlugin : KtPlugin<Project> {
             dryRun = bintrayDryRun == "true"
 
             pkg.apply {
-                if (bintrayUserOrg != null)
+                if (bintrayUserOrg.isNotEmpty())
                     userOrg = bintrayUserOrg
                 repo = rootExt.repo
                 setLicenses("MIT")

--- a/src/main/kotlin/org/kodein/internal/gradle/KodeinUploadPlugin.kt
+++ b/src/main/kotlin/org/kodein/internal/gradle/KodeinUploadPlugin.kt
@@ -54,7 +54,7 @@ class KodeinUploadPlugin : KtPlugin<Project> {
 
                 if (snapshotNumber != null) {
                     repo = "kodein-dev"
-                    project.version = "${project.version}-$snapshotNumber"
+                    project.version = "${project.version}-dev-$snapshotNumber"
                 }
             }
         }

--- a/src/main/kotlin/org/kodein/internal/gradle/KodeinUploadPlugin.kt
+++ b/src/main/kotlin/org/kodein/internal/gradle/KodeinUploadPlugin.kt
@@ -27,13 +27,13 @@ class KodeinUploadPlugin : KtPlugin<Project> {
             return
         }
 
-        val bintrayUsername = "${properties["bintrayUsername"] ?: System.getenv("BINTRAY_USER")}"
-        val bintrayApiKey = "${properties["bintrayApiKey"] ?: System.getenv("BINTRAY_APIKEY")}"
-        val bintrayUserOrg = "${properties["bintrayUserOrg"] ?: System.getenv("BINTRAY_USER_ORG")}"
+        val bintrayUsername = (properties["bintrayUsername"] as String?) ?: System.getenv("BINTRAY_USER")
+        val bintrayApiKey = (properties["bintrayApiKey"] as String?) ?: System.getenv("BINTRAY_APIKEY")
+        val bintrayUserOrg = (properties["bintrayUserOrg"] as String?) ?: System.getenv("BINTRAY_USER_ORG")
         val bintrayDryRun: String? by project
         val snapshotNumber: String? by project
 
-        if (bintrayUsername.isEmpty() || bintrayApiKey.isEmpty()) {
+        if (bintrayUsername == null || bintrayApiKey == null) {
             logger.warn("$project: Ignoring bintrayUpload in because bintrayUsername and/or bintrayApiKey is not set in gradle.properties.")
             return
         }
@@ -44,7 +44,7 @@ class KodeinUploadPlugin : KtPlugin<Project> {
             dryRun = bintrayDryRun == "true"
 
             pkg.apply {
-                if (bintrayUserOrg.isNotEmpty())
+                if (bintrayUserOrg != null)
                     userOrg = bintrayUserOrg
                 repo = rootExt.repo
                 setLicenses("MIT")

--- a/src/main/kotlin/org/kodein/internal/gradle/KodeinUploadPlugin.kt
+++ b/src/main/kotlin/org/kodein/internal/gradle/KodeinUploadPlugin.kt
@@ -1,10 +1,10 @@
 package org.kodein.internal.gradle
 
-import com.jfrog.bintray.gradle.BintrayExtension
-import com.jfrog.bintray.gradle.tasks.BintrayUploadTask
-import org.gradle.api.Project
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
+import com.jfrog.bintray.gradle.*
+import com.jfrog.bintray.gradle.tasks.*
+import org.gradle.api.*
+import org.gradle.api.publish.*
+import org.gradle.api.publish.maven.*
 import org.gradle.kotlin.dsl.*
 
 
@@ -36,6 +36,7 @@ class KodeinUploadPlugin : KtPlugin<Project> {
         val bintrayApiKey: String by project
         val bintrayUserOrg: String? by project
         val bintrayDryRun: String? by project
+        val snapshotNumber: String? by project
 
         bintray.apply {
             user = bintrayUsername
@@ -50,6 +51,11 @@ class KodeinUploadPlugin : KtPlugin<Project> {
                 websiteUrl = "http://kodein.org"
                 issueTrackerUrl = "https://github.com/Kodein-Framework/${rootExt.repo}/issues"
                 vcsUrl = "https://github.com/Kodein-Framework/${rootExt.repo}.git"
+
+                if (snapshotNumber != null) {
+                    repo = "kodein-dev"
+                    project.version = "${project.version}-$snapshotNumber"
+                }
             }
         }
 


### PR DESCRIPTION
1. If the var `snapshotNumber` is present during the `bintrayUpload`:
- we switch the repo to `kodein-dev`
- we upload the project.version with `project.version = "${project.version}-dev-$snapshotNumber"`

> example of gradle build:
`gw check bintrayUpload -PsnapshotNumber=123`
will upload with version `2.6.1-dev-123`

2. Other necessary modification: 
- add dryRun on `kodein-internal-gradle-plugin` itself, avoiding unfortunate uploads
- add the use of environment variable for `BINTRAY_USER` / `BINTRAY_APIKEY` /  `BINTRAY_USER_ORG` to avoid security leak on CI. This allow us to setup secure bintray configuration without displaying it into the Travis console.

3. Add Travis configuration to allow automatic snapshots and releases
